### PR TITLE
Add RemoteTech Compatibility

### DIFF
--- a/GameData/DecoupleWithControl/DecoupleWithControl.cfg
+++ b/GameData/DecoupleWithControl/DecoupleWithControl.cfg
@@ -63,3 +63,20 @@
 		packetCeiling = 5
 	}
 }
+
+@PART[*]:HAS[@MODULE[ModuleDecouple],@MODULE[ModuleToggleCrossfeed]]:NEEDS[RemoteTech]
+{
+	%MODULE[ModuleSPU] {
+	}
+	
+	%MODULE[ModuleRTAntennaPassive]	{
+		%TechRequired = unmannedTech
+		%OmniRange = 3000
+		
+		%TRANSMITTER {
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 15.0
+		}
+	}
+}


### PR DESCRIPTION
I decided to make this change because I use RemoteTech in my game and the decouplers did not behave as they should. While they are fine as is in the stock game, with RemoteTech, they act like crewed parts in that they don't need signal for control and they ignore signal delay.

In this fork, I have corrected this. If RemoteTech is installed, the decouplers now act like the other RemoteTech probe cores (3 km omni-directional antenna and connection required for communication) when RemoteTech is installed. If RemoteTech is not installed, then the behavior of the mod should be unchanged.