### PR TITLE
Update DecoupleWithControl.cfg

### DIFF
--- a/GameData/DecoupleWithControl/DecoupleWithControl.cfg
+++ b/GameData/DecoupleWithControl/DecoupleWithControl.cfg
@@ -63,7 +63,7 @@
 		packetCeiling = 5
 	}
 }
-@PART[*]:HAS[@MODULE[ModuleDecouple],@MODULE[ModuleToggleCrossfeed]]:HAS[!MODULE[ModuleStateFundingDisposable]]:NEEDS[StateFunding]
+@PART[*]:HAS[@MODULE[ModuleDecouple,ModuleToggleCrossfeed]]:HAS[!MODULE[ModuleStateFundingDisposable]]:NEEDS[StateFunding]
 {
 	MODULE
 	{
@@ -89,7 +89,7 @@
 		}
 	}
 }
-@PART[*]:HAS[@MODULE[ModuleDecouple],@MODULE[ModuleToggleCrossfeed]]:NEEDS[RemoteTech]:HAS[!MODULE[ModuleStateFundingDisposable]]:NEEDS[StateFunding]
+@PART[*]:HAS[@MODULE[ModuleDecouple,ModuleToggleCrossfeed]]:NEEDS[RemoteTech]:HAS[!MODULE[ModuleStateFundingDisposable]]:NEEDS[StateFunding]
 {
 	MODULE
 	{


### PR DESCRIPTION
Eliminates duplicate ModuleStateFundingDisposable module creation in parts.

Separate :HAS[] directives for ModuleDecouple & ModuleToggleCrossfeed resulted in duplicate ModuleStateFundingDisposable being created within a part.